### PR TITLE
细节修改

### DIFF
--- a/MyComputerManager/Views/AboutPage.xaml
+++ b/MyComputerManager/Views/AboutPage.xaml
@@ -56,7 +56,7 @@
                    Foreground="{Binding Background, ElementName=Proxy}"
                    Text="GitHub开源地址"
                    TextDecorations="Underline" MouseUp="TextBlock_MouseUp"
-                   FontSize="16" />
+                   FontSize="16" Cursor="Hand" />
         <ui:Button x:Name="Proxy"
                    Width="200" Height="40"
                    Appearance="Primary" Visibility="Collapsed" />


### PR DESCRIPTION
“关于”页面中Github仓库链接上方鼠标悬停效果被改为手形。